### PR TITLE
fix(docs): api property copy event error

### DIFF
--- a/docs/.vuepress/theme/components/Api.vue
+++ b/docs/.vuepress/theme/components/Api.vue
@@ -83,7 +83,7 @@
                 <td class="bugx">
                   <a
                     arget="_blank"
-                    :href="`https://github.com/vuesax-alpha/vuesax-alpha/issues/new?title=[${pageData.title}] prop 
+                    :href="`https://github.com/vuesax-alpha/vuesax-alpha/issues/new?title=[${pageData.title}] prop
                     (${tr.name}) - Your Bug Name&amp;body=**Steps to Reproduce**%0A1. Do something%0A2. Do something else.%0A3. Do one last thing.%0A%0A**Expected**%0AThe ${tr.name} should do this%0A%0A**Result**%0AThe ${tr.name} does not do this%0A%0A**Testcase**%0A(fork this to get started)%0Ahttp://jsfiddle.net/example-bug/1/`"
                   >
                     <i class="bx bx-bug" />
@@ -99,9 +99,8 @@
               </tr>
               <tr v-if="tr.code" class="tr-code">
                 <td
-                  :class="{ copied }"
                   colspan="7"
-                  @click="copy(tr.code)"
+                  @click="handleCopy($event, tr.code)"
                   v-html="getCode(tr.code)"
                 />
               </tr>
@@ -139,7 +138,16 @@ const route = useRoute()
 const pageData = usePageData()
 const pageFrontmatter = usePageFrontmatter<ThemeNormalApiFrontmatter>()
 
-const { copied, copy } = useClipboard({ legacy: true })
+const { copy } = useClipboard({ legacy: true })
+
+const handleCopy = (evt: MouseEvent, code: string) => {
+  copy(code)
+  const tdElement = evt.target as HTMLElement
+  tdElement.classList.add('copied')
+  setTimeout(() => {
+    tdElement.classList.remove('copied')
+  }, 1500)
+}
 
 const getTables = computed((): Tables => {
   return {

--- a/docs/.vuepress/theme/components/Api.vue
+++ b/docs/.vuepress/theme/components/Api.vue
@@ -138,16 +138,24 @@ const route = useRoute()
 const pageData = usePageData()
 const pageFrontmatter = usePageFrontmatter<ThemeNormalApiFrontmatter>()
 
-const { copy } = useClipboard({ legacy: true })
+const { copied, copy } = useClipboard({ legacy: true })
+
+let tdElement: null | HTMLElement = null
 
 const handleCopy = (evt: MouseEvent, code: string) => {
-  copy(code)
-  const tdElement = evt.target as HTMLElement
-  tdElement.classList.add('copied')
-  setTimeout(() => {
+  if (tdElement) {
     tdElement.classList.remove('copied')
-  }, 1500)
+  }
+  copy(code)
+  tdElement = evt.target as HTMLElement
+  tdElement.classList.add('copied')
 }
+
+watch(copied, (newVal) => {
+  if (!newVal && tdElement) {
+    tdElement.classList.remove('copied')
+  }
+})
 
 const getTables = computed((): Tables => {
   return {


### PR DESCRIPTION
closed #58

 document api property copy event error,when open lots of but just click one,all of  opend will  emit copy event style.
 i use new function to contain copy function and use event.target to identify the clicking one,meanwhile use settimeout to replace copied whick is useClipboard's deconstructed
