### PR TITLE
fix(docs): docs api property example open change status error

### DIFF
--- a/docs/.vuepress/theme/components/Api.vue
+++ b/docs/.vuepress/theme/components/Api.vue
@@ -83,7 +83,7 @@
                 <td class="bugx">
                   <a
                     arget="_blank"
-                    :href="`https://github.com/vuesax-alpha/vuesax-alpha/issues/new?title=[${pageData.title}] prop 
+                    :href="`https://github.com/vuesax-alpha/vuesax-alpha/issues/new?title=[${pageData.title}] prop
                     (${tr.name}) - Your Bug Name&amp;body=**Steps to Reproduce**%0A1. Do something%0A2. Do something else.%0A3. Do one last thing.%0A%0A**Expected**%0AThe ${tr.name} should do this%0A%0A**Result**%0AThe ${tr.name} does not do this%0A%0A**Testcase**%0A(fork this to get started)%0Ahttp://jsfiddle.net/example-bug/1/`"
                   >
                     <i class="bx bx-bug" />
@@ -99,9 +99,8 @@
               </tr>
               <tr v-if="tr.code" class="tr-code">
                 <td
-                  :class="{ copied }"
                   colspan="7"
-                  @click="copy(tr.code)"
+                  @click="handleCopy($event, tr.code)"
                   v-html="getCode(tr.code)"
                 />
               </tr>
@@ -139,7 +138,16 @@ const route = useRoute()
 const pageData = usePageData()
 const pageFrontmatter = usePageFrontmatter<ThemeNormalApiFrontmatter>()
 
-const { copied, copy } = useClipboard({ legacy: true })
+const { copy } = useClipboard({ legacy: true })
+
+const handleCopy = (evt: MouseEvent, code: string) => {
+  copy(code)
+  const tdElement = evt.target as HTMLElement
+  tdElement.classList.add('copied')
+  setTimeout(() => {
+    tdElement.classList.remove('copied')
+  }, 1500)
+}
 
 const getTables = computed((): Tables => {
   return {

--- a/docs/.vuepress/theme/components/Api.vue
+++ b/docs/.vuepress/theme/components/Api.vue
@@ -138,16 +138,24 @@ const route = useRoute()
 const pageData = usePageData()
 const pageFrontmatter = usePageFrontmatter<ThemeNormalApiFrontmatter>()
 
-const { copy } = useClipboard({ legacy: true })
+const { copied, copy } = useClipboard({ legacy: true })
+
+let tdElement: null | HTMLElement = null
 
 const handleCopy = (evt: MouseEvent, code: string) => {
-  copy(code)
-  const tdElement = evt.target as HTMLElement
-  tdElement.classList.add('copied')
-  setTimeout(() => {
+  if (tdElement) {
     tdElement.classList.remove('copied')
-  }, 1500)
+  }
+  copy(code)
+  tdElement = evt.target as HTMLElement
+  tdElement.classList.add('copied')
 }
+
+watch(copied, (newVal) => {
+  if (!newVal && tdElement) {
+    tdElement.classList.remove('copied')
+  }
+})
 
 const getTables = computed((): Tables => {
   return {

--- a/docs/.vuepress/theme/components/Api.vue
+++ b/docs/.vuepress/theme/components/Api.vue
@@ -239,6 +239,21 @@ onMounted(() => {
   })
 })
 
+const resetToggleCodeStatus = () => {
+  const toggleCodeBtnList = document.querySelectorAll(
+    '.btn-toggle-code'
+  ) as unknown as Array<HTMLElement>
+
+  toggleCodeBtnList.forEach((toggleBtn: HTMLElement) => {
+    const trParent = toggleBtn.closest('tr')
+    const nextCode = trParent?.nextElementSibling
+    if (nextCode && nextCode.classList.contains('open')) {
+      nextCode.classList.remove('open')
+    }
+    toggleBtn.classList?.remove('open-btn')
+  })
+}
+
 watch(
   () => route.path,
   () => {
@@ -248,6 +263,7 @@ watch(
     document
       .querySelector('.header-page .header__content')
       ?.classList.remove('con-table')
+    resetToggleCodeStatus()
   }
 )
 


### PR DESCRIPTION
when docs api property example opened, i change to other components,this api property example open status is not change.
I watch the route change,when route changed,i get all toggleBtn and nextCode,if it has open status class ,remove them.