### PR TITLE
fix(docs): docs api property example open change status error

### DIFF
--- a/docs/.vuepress/theme/components/Api.vue
+++ b/docs/.vuepress/theme/components/Api.vue
@@ -83,7 +83,7 @@
                 <td class="bugx">
                   <a
                     arget="_blank"
-                    :href="`https://github.com/vuesax-alpha/vuesax-alpha/issues/new?title=[${pageData.title}] prop 
+                    :href="`https://github.com/vuesax-alpha/vuesax-alpha/issues/new?title=[${pageData.title}] prop
                     (${tr.name}) - Your Bug Name&amp;body=**Steps to Reproduce**%0A1. Do something%0A2. Do something else.%0A3. Do one last thing.%0A%0A**Expected**%0AThe ${tr.name} should do this%0A%0A**Result**%0AThe ${tr.name} does not do this%0A%0A**Testcase**%0A(fork this to get started)%0Ahttp://jsfiddle.net/example-bug/1/`"
                   >
                     <i class="bx bx-bug" />
@@ -223,6 +223,21 @@ onMounted(() => {
   })
 })
 
+const resetToggleCodeStatus = () => {
+  const toggleCodeBtnList = document.querySelectorAll(
+    '.btn-toggle-code'
+  ) as unknown as Array<HTMLElement>
+
+  toggleCodeBtnList.forEach((toggleBtn: HTMLElement) => {
+    const trParent = toggleBtn.closest('tr')
+    const nextCode = trParent?.nextElementSibling
+    if (nextCode && nextCode.classList.contains('open')) {
+      nextCode.classList.remove('open')
+    }
+    toggleBtn.classList?.remove('open-btn')
+  })
+}
+
 watch(
   () => route.path,
   () => {
@@ -232,6 +247,7 @@ watch(
     document
       .querySelector('.header-page .header__content')
       ?.classList.remove('con-table')
+    resetToggleCodeStatus()
   }
 )
 


### PR DESCRIPTION
closed #60

## error:
- When docs api property example opened, i change to other components,this api property example open status is not change.
## Solution:
- I watch the route change,when route changed,i get all toggleBtn and nextCode,if it has open status class ,remove them.
