### PR TITLE
fix(theme-chalk): rate scss color function is incorrect

### DIFF
--- a/packages/theme-chalk/src/rate.scss
+++ b/packages/theme-chalk/src/rate.scss
@@ -46,7 +46,7 @@ $rate-size: map.merge(
     position: relative;
     font-size: 0;
     vertical-align: middle;
-    color: getCssVar('rate-void-color');
+    color: getColor('rate-void-color');
     line-height: normal;
   }
 
@@ -99,7 +99,7 @@ $rate-size: map.merge(
   @include when(disabled) {
     @include e(item) {
       cursor: auto;
-      color: getCssVar('rate', 'disabled-void-color');
+      color: getColor('rate-disabled-void-color');
     }
   }
 }


### PR DESCRIPTION
 rate scss color function is incorrect,use getColor replace getCssVar

closed #66

