### PR TITLE
docs(components): [Card] correctly displays the padding-top of h3

### DIFF
--- a/docs/.vuepress/theme/global-components/Card.vue
+++ b/docs/.vuepress/theme/global-components/Card.vue
@@ -178,6 +178,9 @@ h1 {
     h2 {
       padding-top: 120px;
     }
+    h3 {
+      padding-top: 50px;
+    }
     p {
       padding: 5px 20px;
       margin: 0px;


### PR DESCRIPTION
closed #72

see [here](https://vuesax-alpha.vercel.app/components/avatar.html#shape)

The padding-top of h3 in the card component of the global component is a littlelow