### PR TITLE
fix(components): [table] fix unable to sort table data due to case sensitivity issue

### DIFF
--- a/packages/components/table/src/utils.ts
+++ b/packages/components/table/src/utils.ts
@@ -1,4 +1,3 @@
-import { toLower } from 'lodash-unified'
 import { useNamespace } from '@vuesax-alpha/hooks'
 /**
  *

--- a/packages/components/table/src/utils.ts
+++ b/packages/components/table/src/utils.ts
@@ -19,7 +19,7 @@ export const sortData = <T = Record<any, unknown>>(
   sortKey: keyof T,
   type: 'desc' | 'asc' = 'desc'
 ) => {
-  const _sortKey = toLower(String(sortKey))
+  const _sortKey = String(sortKey)
   let sortType: string | undefined = type
   const ns = useNamespace('table')
   const el: HTMLElement | null = event.target as HTMLElement | null


### PR DESCRIPTION
#### Description
I encountered an issue where the sorting functionality of the table component was not working as expected when using camelCase variable names in my data objects. After a code review and comparing with the official example, which uses PascalCase, I found that the difference was in how property names were handled for sorting.

#### Changes Made
- Modified the `sortData` function to remove lowercase conversion (`toLower`) for the `sortKey` parameter.

#### Details
Upon investigating the source code, I discovered that the sorting logic relied on converting `sortKey` to lowercase. This caused issues when my data object's property names were in camelCase, as they were not correctly matched during sorting operations.

#### Note
As a developer primarily using Kotlin and Java, I follow camelCase naming conventions for database entities. This led to the discrepancy with the expected behavior of the sorting mechanism in VueSax.

I referred to the [official example](https://vuesax-alpha.vercel.app/components/table.html#sort) where I observed that modifying the `name` property to `testName` resulted in failure to sort, whereas `testname` worked correctly. This prompted my adjustment in the `sortData` function.

#### Request
This commit is submitted with the understanding that it may diverge from your original design intentions. If this change does not align with your design philosophy, please feel free to reject this commit.

#### Appreciation
I appreciate the thoughtful design of VueSax components and enjoy working with them. Thank you for your efforts in creating such a versatile toolkit.

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow contributing guide [English](https://github.com/vuesax-alpha/vuesax-alpha/blob/main/.github/CONTRIBUTING.md)
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer to relative issues for your PR.
